### PR TITLE
Adds a check for global/window object

### DIFF
--- a/src/base32.js
+++ b/src/base32.js
@@ -10,9 +10,11 @@
 ;(function(root, undefined) {
   'use strict';
 
-  var NODE_JS = typeof(module) != 'undefined';
+  var NODE_JS = typeof(global) != 'undefined';
   if(NODE_JS) {
     root = global;
+  } else {
+    root = window;
   }
 
   var BASE32_ENCODE_CHAR = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'.split('');

--- a/src/base32.js
+++ b/src/base32.js
@@ -11,10 +11,14 @@
   'use strict';
 
   var NODE_JS = typeof(global) != 'undefined';
+  
   if(NODE_JS) {
-    root = global;
-  } else {
-    root = window;
+    if (typeof(window) != 'undefined') {
+      root = window;
+    }
+    else {
+      root = global;
+    }
   }
 
   var BASE32_ENCODE_CHAR = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'.split('');

--- a/tests/test.js
+++ b/tests/test.js
@@ -38,6 +38,14 @@
   ];
 
   describe('base32', function() {
+    
+    describe('window object', function() {
+      it('should work correctly', function() {
+        window = typeof window != 'undefined' ? window : global;
+        expect(base32.encode([72])).to.be('JA======');
+      });
+    });
+
     describe('encode', function() {
       describe('ascii', function() {
         it('should be successful', function() {


### PR DESCRIPTION
When loading webpack and browserify modules in the same combo file, the root object became undefined. Checking explicitly for the window object solve the problem.
